### PR TITLE
Feat/#39 id를 활용한 단일 도서관 정보 조회 api 추가

### DIFF
--- a/src/main/java/com/bookspot/library/application/LibraryService.java
+++ b/src/main/java/com/bookspot/library/application/LibraryService.java
@@ -1,6 +1,8 @@
 package com.bookspot.library.application;
 
 import com.bookspot.library.application.query.Location;
+import com.bookspot.library.domain.Library;
+import com.bookspot.library.domain.LibraryRepository;
 import com.bookspot.library.infra.LibraryRepositoryForView;
 import com.bookspot.library.infra.LocationMBR;
 import com.bookspot.library.presentation.LibraryDistanceResponse;
@@ -13,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LibraryService {
     private final LibraryRepositoryForView repositoryForView;
+    private final LibraryRepository libraryRepository;
 
     public List<LibraryDistanceResponse> findLibraries(Location nw, Location se) {
         return repositoryForView.findLibrariesInBound(
@@ -20,6 +23,26 @@ public class LibraryService {
                         nw.latitude(), nw.longitude(),
                         se.latitude(), se.longitude()
                 )
+        );
+    }
+
+    public LibraryDistanceResponse findLibrary(long libraryId) {
+        Library library = libraryRepository.findById(libraryId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        return toResponse(library);
+    }
+
+    private LibraryDistanceResponse toResponse(Library library) {
+        return new LibraryDistanceResponse(
+                library.getId(),
+                library.getName(),
+                library.getLocation().getY(),
+                library.getLocation().getX(),
+                library.getAddress(),
+                library.getHomePage(),
+                library.getClosedInfo(),
+                library.getOperatingInfo()
         );
     }
 

--- a/src/main/java/com/bookspot/library/domain/Library.java
+++ b/src/main/java/com/bookspot/library/domain/Library.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/bookspot/library/domain/Library.java
+++ b/src/main/java/com/bookspot/library/domain/Library.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.geo.Point;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,4 +21,13 @@ public class Library {
 
     @Column(nullable = false, columnDefinition = "POINT SRID 4326")
     private Point location;
+
+    private String address;
+    private String contactNumber;
+    private String homePage;
+    private String closedInfo;
+    private String operatingInfo;
+    
+    private LocalDate updatedAt;
+    private LocalDate stockUpdatedAt;
 }

--- a/src/main/java/com/bookspot/library/domain/LibraryRepository.java
+++ b/src/main/java/com/bookspot/library/domain/LibraryRepository.java
@@ -1,0 +1,8 @@
+package com.bookspot.library.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LibraryRepository extends JpaRepository<Library, Long> {
+}

--- a/src/main/java/com/bookspot/library/presentation/LibraryController.java
+++ b/src/main/java/com/bookspot/library/presentation/LibraryController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -28,4 +29,12 @@ public class LibraryController {
         );
     }
 
+    @GetMapping("/api/libraries/{libraryId}")
+    public ResponseEntity<LibraryDistanceResponse> findLibraries(
+            @PathVariable long libraryId
+    ) {
+        return ResponseEntity.ok(
+                libraryService.findLibrary(libraryId)
+        );
+    }
 }

--- a/src/main/java/com/bookspot/library/presentation/LibraryController.java
+++ b/src/main/java/com/bookspot/library/presentation/LibraryController.java
@@ -8,17 +8,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @BasicLog
+@RequestMapping("/api/libraries")
 @RestController
 @RequiredArgsConstructor
 public class LibraryController {
     private final LibraryService libraryService;
 
-    @GetMapping("/api/libraries")
+    @GetMapping
     public ResponseEntity<List<LibraryDistanceResponse>> findLibraries(
             @Valid LibrarySearchRequest request) {
         return ResponseEntity.ok(
@@ -29,7 +31,7 @@ public class LibraryController {
         );
     }
 
-    @GetMapping("/api/libraries/{libraryId}")
+    @GetMapping("/{libraryId}")
     public ResponseEntity<LibraryDistanceResponse> findLibraries(
             @PathVariable long libraryId
     ) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,6 @@ spring:
         format_sql: true
         show_sql: true
         default_batch_fetch_size: 100
+        # Deprecated인 클래스임.  JDBC 공식 스펙이 아니기 때문이라는 듯. 괜찮나...?
+        dialect: org.hibernate.spatial.dialect.mysql.MySQLSpatialDialect
+

--- a/src/test/java/com/bookspot/library/presentation/LibraryControllerTest.java
+++ b/src/test/java/com/bookspot/library/presentation/LibraryControllerTest.java
@@ -1,0 +1,31 @@
+package com.bookspot.library.presentation;
+
+import com.bookspot.library.application.LibraryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LibraryController.class)
+class LibraryControllerTest {
+    @Autowired
+    MockMvc mvc;
+    @MockBean LibraryService libraryService;
+
+    @Test
+    void 도서관_위도_경도_검색() throws Exception {
+        mvc.perform(get("http://localhost:8080/api/libraries?nwLat=0&nwLon=0&seLat=0&seLon=0"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 도서관_단일_검색() throws Exception {
+        mvc.perform(get("http://localhost:8080/api/libraries/1"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- 프론트엔드 도서관 단일 검색 기능 필요에 따른 도서관 단일 검색 API 추가
- #39 

<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
