### PR TITLE
Feat/#41 OpenSearch 동일 키워드 검색 불가능 해결 / 무조건적인 대출 수 정렬 문제 해결

### DIFF
--- a/src/main/java/com/bookspot/book/infra/search/BookOpenSearchRepository.java
+++ b/src/main/java/com/bookspot/book/infra/search/BookOpenSearchRepository.java
@@ -41,6 +41,7 @@ public class BookOpenSearchRepository implements BookSearchRepository {
                                 builder.minimumShouldMatch("1")
                                         .should(
                                                 matchPhrase("title", searchRequest.getKeyword(), 1),
+                                                match("title.ngram", searchRequest.getKeyword()),
                                                 matchPhrase("author", searchRequest.getKeyword()),
                                                 term("publisher", searchRequest.getKeyword())
                                         );
@@ -86,6 +87,14 @@ public class BookOpenSearchRepository implements BookSearchRepository {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private Query match(String fieldName, String keyword) {
+        return new Query.Builder()
+                .match(mp -> mp.field(fieldName)
+                        .query(f -> f.stringValue(keyword))
+                )
+                .build();
     }
 
     private Query matchPhrase(String fieldName, String keyword) {

--- a/src/main/java/com/bookspot/book/infra/search/BookOpenSearchRepository.java
+++ b/src/main/java/com/bookspot/book/infra/search/BookOpenSearchRepository.java
@@ -40,7 +40,7 @@ public class BookOpenSearchRepository implements BookSearchRepository {
                             if(searchRequest.hasKeyword())
                                 builder.minimumShouldMatch("1")
                                         .should(
-                                                matchPhrase("title", searchRequest.getKeyword()),
+                                                matchPhrase("title", searchRequest.getKeyword(), 1),
                                                 matchPhrase("author", searchRequest.getKeyword()),
                                                 term("publisher", searchRequest.getKeyword())
                                         );
@@ -91,6 +91,12 @@ public class BookOpenSearchRepository implements BookSearchRepository {
     private Query matchPhrase(String fieldName, String keyword) {
         return new Query.Builder()
                 .matchPhrase(mp -> mp.field(fieldName).query(keyword))
+                .build();
+    }
+
+    private Query matchPhrase(String fieldName, String keyword, int slopCnt) {
+        return new Query.Builder()
+                .matchPhrase(mp -> mp.field(fieldName).query(keyword).slop(slopCnt))
                 .build();
     }
 


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #41

## 이후 PR 계획
- 검색 고도화 필요

## 참고
내가 정리한 글
- [velog - 문서와 정확히 일치하는 한글 문자열 검색 실패 문제 해결(match_phrase)](https://velog.io/@sdsd0908/ElasticSearch-%EB%8F%99%EC%9D%BC%ED%95%9C-%ED%82%A4%EC%9B%8C%EB%93%9C%EB%A1%9C-%EA%B2%80%EC%83%89%ED%96%88%EB%8A%94%EB%8D%B0-%EB%82%98%EC%98%A4%EC%A7%80-%EC%95%8A%EB%8A%94-%EB%AC%B8%EC%A0%9C-matchphrase)
- [velog - "이기적"으로 검색해도 "이기적 유전자"가 검색되지 않는 문제 해결 (edge_ngram)](https://velog.io/@sdsd0908/%EC%9D%B4%EA%B8%B0%EC%A0%81%EC%9C%BC%EB%A1%9C-%EA%B2%80%EC%83%89%ED%95%B4%EB%8F%84-%EC%9D%B4%EA%B8%B0%EC%A0%81-%EC%9C%A0%EC%A0%84%EC%9E%90%EA%B0%80-%EA%B2%80%EC%83%89%EB%90%98%EC%A7%80-%EC%95%8A%EB%8A%94-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)
 
