### PR TITLE
fix: LocalDate 직렬화 오류 해결

### DIFF
--- a/src/main/java/com/bookspot/stock/application/LibraryStockRefreshService.java
+++ b/src/main/java/com/bookspot/stock/application/LibraryStockRefreshService.java
@@ -25,10 +25,10 @@ public class LibraryStockRefreshService {
         LibraryStock stock = libraryStockRepository.findById(stockId)
                 .orElseThrow(IllegalArgumentException::new);
         if(stock.isAlreadyRefreshed(dateHolder))
-            return new StockLoanStateResponse(
+            return LibraryStockDataMapper.transform(
                     stock.getId(),
                     stock.getUpdatedAt(),
-                    LibraryStockDataMapper.transform(stock.getLoanState())
+                    stock.getLoanState()
             );
 
         // TODO: 락을 다루는 일이기 떄문에 batch 처리와 충돌이 있을 수 있음. 관리 필요. 그래도 only 레코드 락이라...
@@ -42,10 +42,8 @@ public class LibraryStockRefreshService {
                 stockWithBookAndLibrary.getLibrary()
         );
 
-        return new StockLoanStateResponse(
-                stock.getId(),
-                now,
-                LibraryStockDataMapper.transform(result)
+        return LibraryStockDataMapper.transform(
+                stock.getId(), now, result
         );
     }
 }

--- a/src/main/java/com/bookspot/stock/application/mapper/LibraryStockDataMapper.java
+++ b/src/main/java/com/bookspot/stock/application/mapper/LibraryStockDataMapper.java
@@ -5,11 +5,25 @@ import com.bookspot.stock.domain.LoanState;
 import com.bookspot.stock.presentation.response.LoanStateResponseEnum;
 import com.bookspot.stock.presentation.response.StockLoanStateResponse;
 
+import java.time.LocalDate;
+
 public class LibraryStockDataMapper {
+    public static StockLoanStateResponse transform(
+            long stockId,
+            LocalDate stateUpdatedAt,
+            LoanState loanState
+    ) {
+        return new StockLoanStateResponse(
+                stockId,
+                stateUpdatedAt.toString(),
+                transform(loanState)
+        );
+    }
+
     public static StockLoanStateResponse transform(LibraryStock stock) {
         return new StockLoanStateResponse(
                 stock.getId(),
-                stock.getUpdatedAt(),
+                stock.getUpdatedAt().toString(),
                 transform(stock.getLoanState())
         );
     }

--- a/src/main/java/com/bookspot/stock/presentation/response/StockLoanStateResponse.java
+++ b/src/main/java/com/bookspot/stock/presentation/response/StockLoanStateResponse.java
@@ -1,10 +1,8 @@
 package com.bookspot.stock.presentation.response;
 
-import java.time.LocalDate;
-
 public record StockLoanStateResponse(
         long stockId,
-        LocalDate stateUpdatedAt,
+        String stateUpdatedAt,
         LoanStateResponseEnum loanState
 ) {
 }


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- LocalDate 직렬화 오류 해결
- 에러 로그
```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.LocalDate` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: com.bookspot.TempController$TempResponse["date"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1308) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.impl.UnsupportedTypeSerializer.serialize(UnsupportedTypeSerializer.java:35) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:732) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:772) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:479) ~[jackson-databind-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:318) ~[jackson-databind-2.15.3.jar:2.15.3]
```

- 원인 : ObjectMapper 빈 등록 -> Spring Boot의 자동 설정이 덮어씌워짐 -> JavaTimeModule 무시됨 -> LocalDate 직렬화 문제 발생
<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
