### PR TITLE
feat 사용자 엔티티에 createdAt updatedAt 필드 추가

### DIFF
--- a/src/main/java/com/bookspot/users/domain/Users.java
+++ b/src/main/java/com/bookspot/users/domain/Users.java
@@ -10,7 +10,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -22,6 +26,7 @@ import java.util.UUID;
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Users {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,6 +50,11 @@ public class Users {
 
     private int bookBagSize = 0;
     private int shelfSize = 0;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     private Users(
             String email,


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #153 

```sql
ALTER TABLE users
ADD COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
```


<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
